### PR TITLE
Fix textSprite_T X pos

### DIFF
--- a/cl_dll/hud/scoreboard.cpp
+++ b/cl_dll/hud/scoreboard.cpp
@@ -775,7 +775,7 @@ int CHudScoreboard::DrawTopScoreBoard(float flTime)
 		wrect_t textRect = gHUD.GetSpriteRect(m_iTTextIndex);
 
 		SPR_Set(textSprite_T, 128, 128, 128);
-		SPR_DrawAdditive(0, (ScreenWidth) / 2 - 45, bgY + 11, &textRect);
+		SPR_DrawAdditive(0, (ScreenWidth) / 2 - 50, bgY + 11, &textRect);
 	}
 
 	HSPRITE textSprite_CT = gHUD.GetSprite(m_iCTTextIndex);

--- a/cl_dll/hud/scoreboard.cpp
+++ b/cl_dll/hud/scoreboard.cpp
@@ -157,7 +157,7 @@ int CHudScoreboard :: VidInit( void )
 
 	m_iBGIndex = m_iOriginalBG;
 	m_iTextIndex = m_iText_Round;
-	m_iTTextIndex = m_iText_T;
+	m_iTTextIndex = m_iText_TR;
 	m_iCTTextIndex = m_iText_CT;
 	m_bIsTeamplay = true;
 


### PR DESCRIPTION
Fixes #9
Before:
![default](https://user-images.githubusercontent.com/25232950/43990542-2ed3c9ec-9d65-11e8-88c1-2d0b3f06225d.png)

After:
![default](https://user-images.githubusercontent.com/25232950/43990544-32bec016-9d65-11e8-972e-db27b7c7a2ec.png)
